### PR TITLE
MP Download Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ python download/download_materials_project.py \
 	--out_path ./data/mp_raw \
 	--workers WORKERS \
 	--task_id_file ./data/mpid_to_task_id_map.json \
-	--mpi_api_key <"Your MP API Key">
+	--mp_api_key <"Your MP API Key">
 ```
 
 Optionally, you can exclude the `task_id_file` to download the latest data from materials project, including any updates to the dataset since we obtained a copy. For reproducible results, use the above call.
@@ -148,7 +148,7 @@ Optionally, you can exclude the `task_id_file` to download the latest data from 
 python download/download_materials_project.py \
 	--out_path ./data/mp_raw \
 	--workers WORKERS \
-	--mpi_api_key <"Your MP API Key">
+	--mp_api_key <"Your MP API Key">
 ```
 
 2. Convert the CHGCAR files to numpy and pickle files for faster reading with [scripts/batch_pickle_mp_charge_density.py](./scripts/batch_pickle_mp_charge_density.py)

--- a/README.md
+++ b/README.md
@@ -137,10 +137,14 @@ python src/train_from_config.py -cd configs/charge3net -cn train_nmc_e3_final.ya
 ```bash
 python download/download_materials_project.py \
 	--out_path ./data/mp_raw \
-	--workers WORKERS \
+	--workers <number of workers> \
 	--task_id_file ./data/mpid_to_task_id_map.json \
-	--mp_api_key <"Your MP API Key">
+	--mp_api_key <MP API key>
 ```
+
+**Update 2024:** The Materials Project API has updated their backend, and as a
+result some of the [old task ids are no longer accessable](https://github.com/materialsproject/api/issues/924#issuecomment-2329837586). We have added a flag
+to the above command `--download_latest_for_missing_task_id`, which will download the latest calculations for these missing task ids. Note that this will result in data that is slightly different from our published work.
 
 Optionally, you can exclude the `task_id_file` to download the latest data from materials project, including any updates to the dataset since we obtained a copy. For reproducible results, use the above call.
 
@@ -148,7 +152,7 @@ Optionally, you can exclude the `task_id_file` to download the latest data from 
 python download/download_materials_project.py \
 	--out_path ./data/mp_raw \
 	--workers WORKERS \
-	--mp_api_key <"Your MP API Key">
+	--mp_api_key <MP API key>
 ```
 
 2. Convert the CHGCAR files to numpy and pickle files for faster reading with [scripts/batch_pickle_mp_charge_density.py](./scripts/batch_pickle_mp_charge_density.py)

--- a/download/download_materials_project.py
+++ b/download/download_materials_project.py
@@ -21,6 +21,7 @@ parser.add_argument("--limit", type=int, default=0,
 parser.add_argument("--workers", type=int, default=1)
 parser.add_argument("--task_id_file", type=str, help="(optional) json file mapping from `material_id`s to `task_id`s")
 parser.add_argument("--mp_api_key", type=str, help="API Key from materials project")
+parser.add_argument("--download_latest_for_missing_task_id", action="store_true", help="Download latest material id charge density if task id is missing")
 
 
 def get_charge_density_with_task_docs(MP_API_KEY: str, mpid: str, deserialize: bool = False) -> Tuple[Chgcar, TaskDoc]:
@@ -47,38 +48,16 @@ def get_charge_density_with_task_docs(MP_API_KEY: str, mpid: str, deserialize: b
 
 
 def get_charge_density_and_task_docs_by_task_id(MP_API_KEY: str, task_id: str, deserialize: bool = False) -> Tuple[Chgcar, TaskDoc]:
-    r'''Retrieve charge density and the associated TaskDoc, from the task_id
-
-        This requires a few more steps than get_charge_density_with_task_docs, since this is not supported
-        with the existing mp_api package
-    
-    '''
+    r'''Retrieve charge density and the associated TaskDoc, from the task_id'''
     with MPRester(MP_API_KEY, monty_decode=deserialize) as mpr:
-        task_doc = mpr.materials.tasks.get_data_by_id(task_id)
-
-        # work-around to get charge density from task_id. See: 
-        # https://github.com/materialsproject/api/issues/924
-
-        # results = mpr.materials.search(task_ids=[task_id])  # type: ignore
-        # assert len(results) == 1
-        # chgcar = mpr.charge_density.get_charge_density_from_file_id(results[0].fs_id)
-        decoder = MontyDecoder().decode if deserialize else json.loads
-        chgcar = (
-            mpr.tasks._query_open_data(
-                bucket="materialsproject-parsed",
-                key=f"chgcars/{str(task_id)}.json.gz",
-                decoder=decoder,
-                fields=["data"],
-            )[0][0]["data"]
-            or {}
-        )
+        chgcar, task_doc = mpr.get_charge_density_from_task_id(task_id, inc_task_doc=True)
         return chgcar, task_doc
 
 
 def get_materials_with_charge_density(MP_API_KEY: str) -> list:
     r'''Returns a list of material ids that have charge density data'''
     with MPRester(MP_API_KEY) as mpr:
-        docs = mpr.summary.search(has_props = [HasProps.charge_density], fields=["material_id"])
+        docs = mpr.materials.summary.search(has_props = [HasProps.charge_density], fields=["material_id"])
     charge_density_mpids = [doc.material_id for doc in docs]
     return charge_density_mpids
 
@@ -124,12 +103,21 @@ def _read_in_write_out(mp_api_key: str, mpid: str, outpath: Union[Path, str]):
         write_task_id_to_txt(taskdoc=taskdoc, root_dir=outpath, mpid=mpid)
         
         
-def _read_in_write_out_task(mp_api_key: str, mpid: str, task_id: str, outpath: Union[Path, str]):
+def _read_in_write_out_task(
+    mp_api_key: str,
+    mpid: str,
+    task_id: str,
+    outpath: Union[Path, str],
+    download_latest_for_missing_task_id: bool = False,
+):
     outpath=Path(outpath)
     try:
         chgcar, taskdoc = get_charge_density_and_task_docs_by_task_id(mp_api_key, task_id, deserialize=True)
     except Exception as e:
         print(e)
+        if download_latest_for_missing_task_id:
+            print(f"task id {task_id} failed, falling back to latest calculation for mpid {mpid}")
+            _read_in_write_out(mp_api_key, mpid, outpath)
         return
 
     if chgcar is not None:
@@ -169,11 +157,11 @@ def main(args):
             raise ValueError("Num workers should be less than 5, to avoid strain on MP servers") 
         elif args.workers > 1:
             print(f"Starting API calls with {args.workers} workers...")
-            pool.Pool(args.workers).starmap(_read_in_write_out_task, [(args.mp_api_key, mpid, task_id, args.out_path) for mpid, task_id in zip(mpids, task_ids)])
+            pool.Pool(args.workers).starmap(_read_in_write_out_task, [(args.mp_api_key, mpid, task_id, args.out_path, args.download_latest_for_missing_task_id) for mpid, task_id in zip(mpids, task_ids)])
         else:
             print("Starting API call with a single worker. Add additional workers with --workers")
             for mpid, task_id in zip(mpids, task_ids):
-                _read_in_write_out_task(args.mp_api_key, mpid, task_id, args.out_path)
+                _read_in_write_out_task(args.mp_api_key, mpid, task_id, args.out_path, args.download_latest_for_missing_task_id)
             
             
     else:


### PR DESCRIPTION
Addresses #7 #2. Updates materials project download code for their new API. Allows downloading latest calculations where old task ids are not available to download.