### PR TITLE
fixing typing of spin density

### DIFF
--- a/src/charge3net/models/e3.py
+++ b/src/charge3net/models/e3.py
@@ -321,7 +321,7 @@ class E3ProbeMessageModel(torch.nn.Module):
 
         # last layer, scalar output
         if spin:
-            out = "2x0e"
+            out = "1x0e+1x0o"
         else:
             out = "0e"
         self.readout = Linear(irreps_node, out)


### PR DESCRIPTION
If spin density is being predicted, the output should be a scalar for charge density (`1x0e`) and pseudoscalar for spin density (`1x0o`). 